### PR TITLE
Handle data as binary when reading from BLE

### DIFF
--- a/src/ble-bt-tnc/ble-bt-tnc.ino
+++ b/src/ble-bt-tnc/ble-bt-tnc.ino
@@ -61,16 +61,17 @@ class MyCallbacks : public BLECharacteristicCallbacks
   // Data was written from the phone to the adapter
   void onWrite(BLECharacteristic *pCharacteristic)
   {
-    std::string rxValue = pCharacteristic->getValue();
-    if (rxValue.length() > 0)
-    {
+    if (pCharacteristic->getLength() > 0)
+    {   
+        int valLength = pCharacteristic->getLength();
+        byte *pValData = pCharacteristic->getData();
         Serial.println("Received Value from aprs.fi App: ");
-        for (int i = 0; i < rxValue.length(); i++){
-          Serial.print(rxValue[i]);
+        for (int i = 0; i < valLength; i++){
+          Serial.print(char(*(pValData+i)));
         }
         Serial.println("...");
         Serial.println("Send received values via UART");
-        SerialPort.write(pCharacteristic->getData(), rxValue.length());
+        SerialPort.write(pValData, valLength);
     }
   }
 };


### PR DESCRIPTION
Using the conversion of the data received via BLE to std::string does not work reliably when there are zero value bytes in the data. Also, as a byproduct of that, determining the length of the data based on the resulting string length also led to data corruption when sending the data to the TNC. Changed the approach to use binary data.

This is based on using a Seeed Studio Xiao ESP32C3 with a Raspberry Pi Zero 2W running Direwolf. 